### PR TITLE
Change `formatDate` to make timezone optional, change format

### DIFF
--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -1,9 +1,9 @@
 import moment from 'moment-timezone'
 
 function formatDate (date,
-                     timezone,
-                     timeFormat = 'h:mma',
                      {
+                       timezone=false,
+                       timeFormat = 'h:mma',
                        hourLabel = 'hour',
                        hoursLabel = 'hours',
                        minuteLabel = 'min',
@@ -11,8 +11,8 @@ function formatDate (date,
                        dayLabel = 'day',
                        daysLabel = 'days'
                      } = {}) {
-  const momentDate = moment.utc(date).tz(timezone)
-  const today = moment.utc(new Date()).tz(timezone)
+  const momentDate = timezone ? moment.utc(date).tz(timezone) : moment(date)
+  const today = timezone ? moment.utc(new Date()).tz(timezone) : moment(new Date())
   const isToday = moment(today).isSame(momentDate, 'day')
   const isThisYear = moment(today).isSame(momentDate, 'year')
 

--- a/test/formatDate.spec.js
+++ b/test/formatDate.spec.js
@@ -7,7 +7,7 @@ describe('formatDate specs', () => {
   const time12Hour = 'h:mma'
   const time24Hour = 'H:mm'
   // 5/4/2017 noon - UTC time
-  const date = moment.utc('2017-05-04 12:00:00').tz(timezone).toDate()
+  const now = moment.utc('2017-05-04 12:00:00').tz(timezone).toDate()
   const justNow = moment.utc('2017-05-04 11:59:35').tz(timezone).toDate()
   const oneMinuteAgo = moment.utc('2017-05-04 11:59:00').tz(timezone).toDate()
   const minutesAgo = moment.utc('2017-05-04 11:45:00').tz(timezone).toDate()
@@ -21,7 +21,7 @@ describe('formatDate specs', () => {
   let clock
 
   beforeEach(() => {
-    clock = sinon.useFakeTimers(date.getTime())
+    clock = sinon.useFakeTimers(now.getTime())
     // "Now" Should be 7AM Central time
     expect(moment.utc().tz(timezone).format('YYYY-MM-DD h:mm:ss')).toBe('2017-05-04 7:00:00')
   })
@@ -53,29 +53,42 @@ describe('formatDate specs', () => {
     [lastYear, time24Hour, 'Dec 24, \'16']
   ]
   testCases.forEach((test) => {
-    const [dateTime, format, expected] = test
-    it(`should convert ${dateTime} to ${expected} with format ${format}`, () => {
-      expect(formatDate(dateTime, timezone, format)).toBe(expected)
+    const [dateTime, timeFormat, expected] = test
+    it(`should convert ${dateTime} to ${expected} with format ${timeFormat}`, () => {
+      expect(formatDate(dateTime, { timezone, timeFormat })).toBe(expected)
     })
+  })
+
+  it('should handle empty timezone by defaulting to system timezone', () => {
+    // 7 hours behind UTC
+    moment.tz.setDefault('America/Los_Angeles')
+    expect(formatDate(today)).toBe('2:15am')
+    // 10 hours behind UTC
+    moment.tz.setDefault('Pacific/Honolulu')
+    expect(formatDate(today)).toBe('2 hours ago')
+    // 4 hours behind UTC
+    moment.tz.setDefault('US/Eastern')
+    expect(formatDate(today, {timeFormat: 'H:mm'})).toBe('5:15')
+    moment.tz.setDefault()
   })
 
   it('should respect the hour/hours label options', () => {
     const hourLabel = 'H';
     const hoursLabel = 'Hs';
-    expect(formatDate(yesterdayHoursAgo, timezone, time12Hour, { hourLabel, hoursLabel })).toBe(`19 ${hoursLabel} ago`)
+    expect(formatDate(yesterdayHoursAgo, { timezone, timeFormat: time12Hour, hourLabel, hoursLabel })).toBe(`19 ${hoursLabel} ago`)
   })
 
   it('should respect the minute/minutes label options', () => {
     const minuteLabel = 'minute';
     const minutesLabel = 'minutes';
-    expect(formatDate(oneMinuteAgo, timezone, time12Hour, { minuteLabel, minutesLabel })).toBe(`1 ${minuteLabel} ago`)
-    expect(formatDate(minutesAgo, timezone, time12Hour, { minuteLabel, minutesLabel })).toBe(`15 ${minutesLabel} ago`)
+    expect(formatDate(oneMinuteAgo, { timezone, timeFormat: time12Hour, minuteLabel, minutesLabel })).toBe(`1 ${minuteLabel} ago`)
+    expect(formatDate(minutesAgo, { timezone, timeFormat: time12Hour, minuteLabel, minutesLabel })).toBe(`15 ${minutesLabel} ago`)
   })
 
   it('should respect the day/days label options', () => {
     const dayLabel = 'd';
     const daysLabel = 'dayz';
-    expect(formatDate(oneDayAgo, timezone, time12Hour, { dayLabel, daysLabel })).toBe(`1 ${dayLabel} ago`)
-    expect(formatDate(daysAgo, timezone, time12Hour, { dayLabel, daysLabel })).toBe(`2 ${daysLabel} ago`)
+    expect(formatDate(oneDayAgo, { timezone, timeFormat: time12Hour, dayLabel, daysLabel })).toBe(`1 ${dayLabel} ago`)
+    expect(formatDate(daysAgo, { timezone, timeFormat: time12Hour, dayLabel, daysLabel })).toBe(`2 ${daysLabel} ago`)
   })
 })


### PR DESCRIPTION
We need to be able to leave off `timezone`. This PR moves all parameters except the timestamp into an `options` map with default values. 

The format has changed from `formatDate(timestamp, {timezone, timeFormat, ...displayOptions})` to `formatDate(timestamp, timezone, timeFormat, displayOptions)`.