### PR TITLE
Add condensed label option

### DIFF
--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -9,7 +9,8 @@ function formatDate (date,
                        minuteLabel = 'min',
                        minutesLabel = 'min',
                        dayLabel = 'day',
-                       daysLabel = 'days'
+                       daysLabel = 'days',
+                       condensed = false,
                      } = {}) {
   const momentDate = timezone ? moment.utc(date).tz(timezone) : moment(date)
   const today = timezone ? moment.utc(new Date()).tz(timezone) : moment(new Date())
@@ -33,6 +34,9 @@ function formatDate (date,
   }
   if (minutes < 60) {
     const label = minutes > 1 ? minutesLabel : minuteLabel
+    if (condensed === true) {
+      return `${minutes}${label.charAt(0)}`
+    }
     return `${minutes} ${label} ago`
   }
   if (hours < 24) {
@@ -40,10 +44,16 @@ function formatDate (date,
       return momentDate.format(timeFormat)
     }
     const label = hours > 1 ? hoursLabel : hourLabel
+    if (condensed === true) {
+      return `${hours}${label.charAt(0)}`
+    }
     return `${hours} ${label} ago`
   }
   if (hours >= 24 && days < 7) {
     const label = days > 1 ? daysLabel : dayLabel
+    if (condensed === true) {
+      return `${days}${label.charAt(0)}`
+    }
     return `${days} ${label} ago`
   }
   const dateFormat = 'MMM D, \'YY'

--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -23,6 +23,10 @@ function formatDate (date,
   const hours = Math.floor(duration.asHours())
   const days = Math.floor(duration.asDays())
 
+  const formatOutput = (label, value) => {
+    return condensed === true ? `${value}${label.charAt(0)}` : `${value} ${label} ago`
+  }
+
   // IF the time is in the past minute, show "Just Now"
   // IF the time is in the last hour, show minutes since (i.e. 2 min. ago)
   // IF the time is from today - show the hourly time (i.e. 6:00pm, or 9:06am)
@@ -34,27 +38,18 @@ function formatDate (date,
   }
   if (minutes < 60) {
     const label = minutes > 1 ? minutesLabel : minuteLabel
-    if (condensed === true) {
-      return `${minutes}${label.charAt(0)}`
-    }
-    return `${minutes} ${label} ago`
+    return formatOutput(label, minutes)
   }
   if (hours < 24) {
     if (isToday) {
       return momentDate.format(timeFormat)
     }
     const label = hours > 1 ? hoursLabel : hourLabel
-    if (condensed === true) {
-      return `${hours}${label.charAt(0)}`
-    }
-    return `${hours} ${label} ago`
+    return formatOutput(label, hours)
   }
   if (hours >= 24 && days < 7) {
     const label = days > 1 ? daysLabel : dayLabel
-    if (condensed === true) {
-      return `${days}${label.charAt(0)}`
-    }
-    return `${days} ${label} ago`
+    return formatOutput(label, days)
   }
   const dateFormat = 'MMM D, \'YY'
   const dateFormatThisYear = 'MMM D'

--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -24,7 +24,7 @@ function formatDate (date,
   const days = Math.floor(duration.asDays())
 
   const formatOutput = (label, value) => {
-    return condensed === true ? `${value}${label.charAt(0)}` : `${value} ${label} ago`
+    return condensed === true ? `${value}${label}` : `${value} ${label} ago`
   }
 
   // IF the time is in the past minute, show "Just Now"

--- a/test/formatDate.spec.js
+++ b/test/formatDate.spec.js
@@ -91,4 +91,20 @@ describe('formatDate specs', () => {
     expect(formatDate(oneDayAgo, { timezone, timeFormat: time12Hour, dayLabel, daysLabel })).toBe(`1 ${dayLabel} ago`)
     expect(formatDate(daysAgo, { timezone, timeFormat: time12Hour, dayLabel, daysLabel })).toBe(`2 ${daysLabel} ago`)
   })
+
+  it('should respect the condensed option', () => {
+    const condensed = true;
+    const hourLabel = 'hour';
+    const hoursLabel = 'hours';
+    const minuteLabel = 'minute';
+    const minutesLabel = 'minutes';
+    const dayLabel = 'day';
+    const daysLabel = 'days';
+    expect(formatDate(yesterdayHoursAgo, { timezone, timeFormat: time12Hour, hourLabel, hoursLabel, condensed })).toBe('19h');
+    expect(formatDate(oneMinuteAgo, { timezone, timeFormat: time12Hour, minuteLabel, minutesLabel, condensed })).toBe('1m');
+    expect(formatDate(minutesAgo, { timezone, timeFormat: time12Hour, minuteLabel, minutesLabel, condensed })).toBe('15m');
+    expect(formatDate(oneDayAgo, { timezone, timeformat: time12Hour, dayLabel, daysLabel, condensed })).toBe('1d');
+    expect(formatDate(daysAgo, { timezone, timeFormat: time12Hour, dayLabel, daysLabel, condensed })).toBe('2d');
+    expect(formatDate(today, { timezone, timeFormat: time12Hour, condensed })).toBe('4:15am');
+  })
 })

--- a/test/formatDate.spec.js
+++ b/test/formatDate.spec.js
@@ -94,12 +94,12 @@ describe('formatDate specs', () => {
 
   it('should respect the condensed option', () => {
     const condensed = true;
-    const hourLabel = 'hour';
-    const hoursLabel = 'hours';
-    const minuteLabel = 'minute';
-    const minutesLabel = 'minutes';
-    const dayLabel = 'day';
-    const daysLabel = 'days';
+    const hourLabel = 'h';
+    const hoursLabel = 'h';
+    const minuteLabel = 'm';
+    const minutesLabel = 'm';
+    const dayLabel = 'd';
+    const daysLabel = 'd';
     expect(formatDate(yesterdayHoursAgo, { timezone, timeFormat: time12Hour, hourLabel, hoursLabel, condensed })).toBe('19h');
     expect(formatDate(oneMinuteAgo, { timezone, timeFormat: time12Hour, minuteLabel, minutesLabel, condensed })).toBe('1m');
     expect(formatDate(minutesAgo, { timezone, timeFormat: time12Hour, minuteLabel, minutesLabel, condensed })).toBe('15m');


### PR DESCRIPTION
This PR adds an option for a condensed label format which uses only the first letter of the label and drops the `ago` term. For example, `9 minutes ago` is displayed as `9m`. This is as required by https://github.com/helpscout/beacon2/pull/57. 