### PR TITLE
Make moment-timezone optional

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,6 @@ module.exports = {
     ]
   },
   externals: {
-    'moment-timezone': 'moment-timezone'
+    'moment-timezone': 'moment'
   }
 }


### PR DESCRIPTION
Change the `externals` config to allow repositories which import js-utils to determine whether `moment` imports vanilla `moment`, or `moment-timezone`