### PR TITLE
Add label option for 'Just Now'

### DIFF
--- a/src/formatDate.js
+++ b/src/formatDate.js
@@ -10,6 +10,7 @@ function formatDate (date,
                        minutesLabel = 'min',
                        dayLabel = 'day',
                        daysLabel = 'days',
+                       nowLabel = 'Just Now',
                        condensed = false,
                      } = {}) {
   const momentDate = timezone ? moment.utc(date).tz(timezone) : moment(date)
@@ -34,7 +35,7 @@ function formatDate (date,
   // IF the time is greater than 24 hours ago, show the days (i.e. 3 days ago)
   // IF time is greater than 6 days, then show date (i.e. Mar 14, or Dec 12 ’16 if year is NOT current year)
   if (seconds < 60) {
-    return 'Just Now'
+    return nowLabel
   }
   if (minutes < 60) {
     const label = minutes > 1 ? minutesLabel : minuteLabel

--- a/test/formatDate.spec.js
+++ b/test/formatDate.spec.js
@@ -92,6 +92,11 @@ describe('formatDate specs', () => {
     expect(formatDate(daysAgo, { timezone, timeFormat: time12Hour, dayLabel, daysLabel })).toBe(`2 ${daysLabel} ago`)
   })
 
+  it('should respect the now label option', () => {
+    const nowLabel = 'NOW';
+    expect(formatDate(justNow, { timezone, nowLabel })).toBe(nowLabel)
+  })
+
   it('should respect the condensed option', () => {
     const condensed = true;
     const hourLabel = 'h';


### PR DESCRIPTION
Added an option `nowLabel` so we can override the "Just Now" string that is currently hardcoded. This will allow us to translate this into different languages.